### PR TITLE
JRuby patch upgrades

### DIFF
--- a/config_service.gemspec
+++ b/config_service.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'config_service'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.summary     = "A gem to load config yml files"
   s.description = "A gem to load config yml files"
   s.authors     = ['Linh Chau']

--- a/lib/utils/hash_utils.rb
+++ b/lib/utils/hash_utils.rb
@@ -8,7 +8,14 @@ class HashUtils
       elements_with_hash_values.each do |key, value|
         result.send("#{key}=", hash_to_open_struct(value))
       end
+
+      result.extend(OpenStructHashable) if RUBY_PLATFORM == "java"
+
       result
     end
   end
+end
+
+module OpenStructHashable
+  delegate :[], to: :@table
 end

--- a/spec/services/config_service_spec.rb
+++ b/spec/services/config_service_spec.rb
@@ -12,6 +12,12 @@ describe ConfigService do
       allow(File).to receive(:exist?).and_return(false)
       expect {ConfigService.load_config('cache_config.yml')}.to raise_error
     end
+
+    it 'allows access by the :[] method' do
+      config = ConfigService.load_config('memcached.yml')
+      expect { config[:local] }.to_not raise_error
+    end
+
   end
 
   context 'environment' do
@@ -33,4 +39,6 @@ describe ConfigService do
       expect(ConfigService.environment).to eql('dummy')
     end
   end
+
+
 end


### PR DESCRIPTION
I made the JRuby patch more robust. Now you can access the OpenStruct like a hash with string or symbol. Also it extends the OpenStruct with single nested hashes.